### PR TITLE
Add merge script and dataset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Address Dataset Preparation
+
+This repository contains two address datasets from St. Lucie County, Florida:
+
+- **`ST LUCIE_2025-07-01.csv`** – Base address file in the St. Lucie format with 20 columns (number, street name, lat/lon, etc.).
+- **`compressed_data (1).csv.gz`** – A gzipped export from the county GIS system with 55 columns.
+
+The goal is to combine the new GIS records with the existing St. Lucie table while retaining the original column layout.
+
+## Cleaning workflow
+
+1. Decompress and load `compressed_data (1).csv.gz` using pandas.
+2. Rename GIS columns to the St. Lucie column names:
+   - `addrnum` → `NUMBER`
+   - `roadpredir` → `PREDIR`
+   - `roadname` → `STNAME`
+   - `roadtype` → `STSUFFIX`
+   - `roadpostdir` → `POSTDIR`
+   - `unittype` → `UNITTYPE`
+   - `unitid` → `UNITNUM`
+   - `postcomm` → `MAILCITY`
+   - `postal` → `ZIP`
+   - `municipality` → `JURISDICTION`
+3. Create any remaining St. Lucie columns (`ZIP+4`, `LAT`, `LONG`, `FEATID`, `COUNTYID`, `COUNTY`, `FIRECODE`, `POLCODE`, `EFFDATE`, `TDTCODE`) and fill them with `NA` where not supplied. `COUNTYID` is set to `111` and `COUNTY` is "St. Lucie".
+4. Reorder the columns to match the existing CSV and remove duplicate rows.
+5. Concatenate the cleaned GIS records with `ST LUCIE_2025-07-01.csv`.
+
+## Required tools
+
+- Python 3
+- pandas
+
+Install pandas with `pip install pandas` if needed.
+
+## Running the merge script
+
+Run the provided `merge_addresses.py` script from the repository root:
+
+```bash
+python3 merge_addresses.py "ST LUCIE_2025-07-01.csv" "compressed_data (1).csv.gz" output.csv
+```
+
+The script writes a merged file called `output.csv` containing all original St. Lucie rows followed by the cleaned GIS records.

--- a/merge_addresses.py
+++ b/merge_addresses.py
@@ -1,0 +1,55 @@
+import argparse
+import pandas as pd
+
+STLUCIE_COLUMNS = [
+    'NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR', 'UNITTYPE',
+    'UNITNUM', 'MAILCITY', 'ZIP', 'ZIP+4', 'LAT', 'LONG', 'FEATID',
+    'COUNTYID', 'COUNTY', 'JURISDICTION', 'FIRECODE', 'POLCODE', 'EFFDATE', 'TDTCODE'
+]
+
+RENAME_MAP = {
+    'addrnum': 'NUMBER',
+    'roadpredir': 'PREDIR',
+    'roadname': 'STNAME',
+    'roadtype': 'STSUFFIX',
+    'roadpostdir': 'POSTDIR',
+    'unittype': 'UNITTYPE',
+    'unitid': 'UNITNUM',
+    'postcomm': 'MAILCITY',
+    'postal': 'ZIP',
+    'municipality': 'JURISDICTION',
+}
+
+
+def load_gis_csv(path: str) -> pd.DataFrame:
+    """Load the gzipped GIS export."""
+    return pd.read_csv(path, compression='gzip')
+
+
+def standardize_gis(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert GIS columns to the St. Lucie format."""
+    df = df.rename(columns=RENAME_MAP)
+    for col in STLUCIE_COLUMNS:
+        if col not in df.columns:
+            df[col] = pd.NA
+    df['COUNTY'] = df.get('County', pd.NA).fillna('St. Lucie')
+    df['COUNTYID'] = df['COUNTYID'].fillna(111)
+    return df[STLUCIE_COLUMNS]
+
+
+def merge_datasets(original_csv: str, new_csv: str, output_csv: str) -> None:
+    df_old = pd.read_csv(original_csv)
+    df_new = load_gis_csv(new_csv)
+    df_new = standardize_gis(df_new)
+    merged = pd.concat([df_old, df_new], ignore_index=True)
+    merged.drop_duplicates(inplace=True)
+    merged.to_csv(output_csv, index=False)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Merge new GIS records into St. Lucie dataset')
+    parser.add_argument('stlucie_csv', help='Existing St. Lucie CSV file')
+    parser.add_argument('gis_csv', help='Gzipped GIS export')
+    parser.add_argument('output_csv', help='Output CSV path')
+    args = parser.parse_args()
+    merge_datasets(args.stlucie_csv, args.gis_csv, args.output_csv)


### PR DESCRIPTION
## Summary
- document dataset contents and workflow in README
- implement `merge_addresses.py` for combining GIS export with existing StLucie CSV

## Testing
- `python3 merge_addresses.py 'ST LUCIE_2025-07-01.csv' 'compressed_data (1).csv.gz' merged.csv`

------
https://chatgpt.com/codex/tasks/task_e_687c57f1d83883328aa83a755d7f7352