### PR TITLE
Create Unincorporated dataset

### DIFF
--- a/filter_unincorporated.py
+++ b/filter_unincorporated.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description="Filter for Unincorporated Jurisdiction")
+parser.add_argument("input_csv", help="Input CSV file (can be .gz)")
+parser.add_argument("output_csv", help="Output CSV file")
+args = parser.parse_args()
+
+compression = 'gzip' if args.input_csv.endswith('.gz') else None
+
+df = pd.read_csv(args.input_csv, compression=compression)
+if 'JURISDICTION' not in df.columns:
+    raise SystemExit("Input CSV must contain a JURISDICTION column")
+
+mask = df['JURISDICTION'].str.contains('UNINCORPORATED', case=False, na=False)
+filtered = df[mask]
+
+filtered.to_csv(args.output_csv, index=False)


### PR DESCRIPTION
## Summary
- add script to filter for unincorporated jurisdiction records
- generate `Unincorporated.csv` containing 42k+ records

## Testing
- `python3 filter_unincorporated.py StLucie.csv Unincorporated.csv`


------
https://chatgpt.com/codex/tasks/task_e_688275bc852c8332a6f742b3267a0d85