### PR TITLE
Standardize address cleaning and merging

### DIFF
--- a/clean_siteaddress.py
+++ b/clean_siteaddress.py
@@ -15,7 +15,6 @@ columns_to_keep = {
     'unitid': 'UNITNUM',
     'postcomm': 'MAILCITY',
     'postal': 'ZIP',
-    'siteaddid': 'FEATID',
     'County': 'COUNTY',
     'municipality': 'JURISDICTION',
     'created_date': 'EFFDATE'
@@ -24,6 +23,23 @@ columns_to_keep = {
 # Read the CSV and select necessary columns
 site_df = pd.read_csv(raw_file, dtype=str)[list(columns_to_keep.keys())]
 site_df.rename(columns=columns_to_keep, inplace=True)
+
+# Convert all fields to uppercase
+site_df = site_df.applymap(lambda x: x.upper() if isinstance(x, str) else x)
+
+# Trim EFFDATE to date-only format
+site_df['EFFDATE'] = (
+    pd.to_datetime(site_df['EFFDATE'], errors='coerce')
+    .dt.date.astype('string')
+    .fillna('')
+)
+
+# Populate constant identifiers
+site_df['FEATID'] = '2403646'
+site_df['COUNTYID'] = '111'
+site_df['COUNTY'] = 'ST. LUCIE'
+site_df['FIRECODE'] = '73'
+site_df['POLCODE'] = '377'
 
 # Ensure all expected columns exist
 all_columns = ['NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR',

--- a/merge_addresses.py
+++ b/merge_addresses.py
@@ -23,7 +23,26 @@ RENAME_MAP = {
 
 def load_gis_csv(path: str) -> pd.DataFrame:
     """Load the gzipped GIS export."""
-    return pd.read_csv(path, compression='gzip')
+    return pd.read_csv(path, compression='gzip', dtype=str)
+
+
+def normalize_df(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.applymap(lambda x: x.upper() if isinstance(x, str) else x)
+    if 'EFFDATE' in df.columns:
+        df['EFFDATE'] = (
+            pd.to_datetime(df['EFFDATE'], errors='coerce')
+            .dt.date.astype('string')
+            .fillna('')
+        )
+    if 'COUNTY' in df.columns:
+        df['COUNTY'] = 'ST. LUCIE'
+    if 'COUNTYID' in df.columns:
+        df['COUNTYID'] = 111
+    if 'JURISDICTION' in df.columns:
+        df['JURISDICTION'] = (
+            df['JURISDICTION'].fillna('UNINCORPORATED').replace('', 'UNINCORPORATED')
+        )
+    return df
 
 
 def standardize_gis(df: pd.DataFrame) -> pd.DataFrame:
@@ -32,13 +51,12 @@ def standardize_gis(df: pd.DataFrame) -> pd.DataFrame:
     for col in STLUCIE_COLUMNS:
         if col not in df.columns:
             df[col] = pd.NA
-    df['COUNTY'] = df.get('County', pd.NA).fillna('St. Lucie')
-    df['COUNTYID'] = df['COUNTYID'].fillna(111)
+    df = normalize_df(df)
     return df[STLUCIE_COLUMNS]
 
 
 def merge_datasets(original_csv: str, new_csv: str, output_csv: str) -> None:
-    df_old = pd.read_csv(original_csv)
+    df_old = normalize_df(pd.read_csv(original_csv, dtype=str))
     df_new = load_gis_csv(new_csv)
     df_new = standardize_gis(df_new)
     merged = pd.concat([df_old, df_new], ignore_index=True)

--- a/process_data.py
+++ b/process_data.py
@@ -1,47 +1,117 @@
 import csv
 import gzip
 
+FIXED_CODES = {
+    'FEATID': '2403646',
+    'COUNTYID': '111',
+    'COUNTY': 'ST. LUCIE',
+    'FIRECODE': '73',
+    'POLCODE': '377',
+}
+
+
+def to_upper(value: str) -> str:
+    return value.upper() if isinstance(value, str) else value
+
+
+def date_only(value: str) -> str:
+    if not value:
+        return ''
+    return value.split('T')[0].split(' ')[0]
+
+
+def build_row(row: dict) -> tuple:
+    return (
+        to_upper(row.get('addrnum', '')),
+        to_upper(row.get('roadpredir', '')),
+        to_upper(row.get('roadname', '')),
+        to_upper(row.get('roadtype', '')),
+        to_upper(row.get('roadpostdir', '')),
+        '',  # UNITTYPE
+        '',  # UNITNUM
+        to_upper(row.get('postcomm', '')),
+        to_upper(row.get('postal', '')),
+        '',  # ZIP+4
+        '',  # LAT
+        '',  # LONG
+        FIXED_CODES['FEATID'],
+        FIXED_CODES['COUNTYID'],
+        FIXED_CODES['COUNTY'],
+        to_upper(row.get('municipality', '')),
+        FIXED_CODES['FIRECODE'],
+        FIXED_CODES['POLCODE'],
+        date_only(row.get('created_date', '')),
+        '',  # TDTCODE
+    )
+
+
+def build_existing_row(row: dict) -> tuple:
+    return (
+        to_upper(row.get('NUMBER', '')),
+        to_upper(row.get('PREDIR', '')),
+        to_upper(row.get('STNAME', '')),
+        to_upper(row.get('STSUFFIX', '')),
+        to_upper(row.get('POSTDIR', '')),
+        '',  # UNITTYPE
+        '',  # UNITNUM
+        to_upper(row.get('MAILCITY', '')),
+        to_upper(row.get('ZIP', '')),
+        '',  # ZIP+4
+        '',  # LAT
+        '',  # LONG
+        FIXED_CODES['FEATID'],
+        FIXED_CODES['COUNTYID'],
+        FIXED_CODES['COUNTY'],
+        to_upper(row.get('JURISDICTION', '')),
+        FIXED_CODES['FIRECODE'],
+        FIXED_CODES['POLCODE'],
+        date_only(row.get('EFFDATE', '')),
+        '',  # TDTCODE
+    )
+
+
 def process_files():
     stlucie_addresses = set()
     with open('StLucie.csv', 'r') as stlucie_file:
-        reader = csv.reader(stlucie_file)
-        header = next(reader)
+        reader = csv.DictReader(stlucie_file)
         for row in reader:
-            stlucie_addresses.add(tuple(row))
+            stlucie_addresses.add(build_existing_row(row))
 
-    with gzip.open('StAddy.csv.gz', 'rt') as staddy_file, gzip.open('PointMatch.csv.gz', 'wt', newline='') as pointmatch_file:
+    with gzip.open('StAddy.csv.gz', 'rt') as staddy_file, gzip.open(
+        'PointMatch.csv.gz', 'wt', newline=''
+    ) as pointmatch_file:
         reader = csv.DictReader(staddy_file)
         writer = csv.writer(pointmatch_file)
 
         # Write header to PointMatch.csv.gz
-        writer.writerow(['NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR', 'UNITTYPE', 'UNITNUM', 'MAILCITY', 'ZIP', 'ZIP+4', 'LAT', 'LONG', 'FEATID', 'COUNTYID', 'COUNTY', 'JURISDICTION', 'FIRECODE', 'POLCODE', 'EFFDATE', 'TDTCODE'])
+        writer.writerow([
+            'NUMBER',
+            'PREDIR',
+            'STNAME',
+            'STSUFFIX',
+            'POSTDIR',
+            'UNITTYPE',
+            'UNITNUM',
+            'MAILCITY',
+            'ZIP',
+            'ZIP+4',
+            'LAT',
+            'LONG',
+            'FEATID',
+            'COUNTYID',
+            'COUNTY',
+            'JURISDICTION',
+            'FIRECODE',
+            'POLCODE',
+            'EFFDATE',
+            'TDTCODE',
+        ])
 
         for row in reader:
-            staddy_address = (
-                row.get('addrnum', ''),
-                row.get('roadpredir', ''),
-                row.get('roadname', ''),
-                row.get('roadtype', ''),
-                row.get('roadpostdir', ''),
-                row.get('unittype', ''),
-                row.get('unitid', ''),
-                row.get('postcomm', ''),
-                row.get('postal', ''),
-                '',  # ZIP+4
-                '',  # LAT
-                '',  # LONG
-                '',  # FEATID
-                '',  # COUNTYID
-                row.get('County', ''),
-                row.get('municipality', ''),
-                '',  # FIRECODE
-                '',  # POLCODE
-                row.get('created_date', ''),
-                ''  # TDTCODE
-            )
-
+            staddy_address = build_row(row)
             if staddy_address not in stlucie_addresses:
                 writer.writerow(staddy_address)
+
 
 if __name__ == '__main__':
     process_files()


### PR DESCRIPTION
## Summary
- Uppercase and normalize SiteAddress08152025 records while assigning fixed identifiers and codes.
- Add PointMatch utilities to uppercase inputs, strip time from EFFDATE, and populate constant FEATID/COUNTYID/FIRECODE/POLCODE.
- Normalize casing and dates in zip-based cleaning and dataset merging for consistent county and jurisdiction values.

## Testing
- `python -m py_compile clean_siteaddress.py process_data.py clean_data.py merge_addresses.py`


------
https://chatgpt.com/codex/tasks/task_e_689f67b044488332853af2889d24ada7