### PR TITLE
Standardize address cleaning and merging

### DIFF
--- a/clean_data.py
+++ b/clean_data.py
@@ -1,53 +1,60 @@
+"""Clean the Unincorporated-Geocoded dataset and produce UC.zip."""
+
 import pandas as pd
 import zipfile
-import os
 
-# Define the path to the zip file and the target CSV file name
-zip_filename = 'Unincorporated-Geocoded.zip'
-csv_filename = 'UC.csv'
-final_zip_name = 'UC.zip'
+from process_data import FIXED_CODES, date_only, to_upper
 
-# Define the columns to keep and their new names
-columns_to_keep = {
-    'USER_NUMBER': 'NUMBER',
-    'USER_PREDIR': 'PREDIR',
-    'USER_STNAME': 'STNAME',
-    'USER_STSUFFIX': 'STSUFFIX',
-    'USER_POSTDIR': 'POSTDIR',
-    'USER_UNITTYPE': 'UNITTYPE',
-    'USER_UNITNUM': 'UNITNUM',
-    'USER_MAILCITY': 'MAILCITY',
-    'USER_ZIP': 'ZIP',
-    'USER_ZIP_4': 'ZIP+4',
-    'USER_LAT': 'LAT',
-    'USER_LONG': 'LONG',
-    'USER_FEATID': 'FEATID',
-    'USER_COUNTYID': 'COUNTYID',
-    'USER_COUNTY': 'COUNTY',
-    'USER_JURISDICTION': 'JURISDICTION',
-    'USER_FIRECODE': 'FIRECODE',
-    'USER_POLCODE': 'POLCODE',
-    'USER_EFFDATE': 'EFFDATE',
-    'USER_TDTCODE': 'TDTCODE'
+
+ZIP_FILENAME = "Unincorporated-Geocoded.zip"
+CSV_FILENAME = "UC.csv"
+FINAL_ZIP_NAME = "UC.zip"
+
+COLUMNS_TO_KEEP = {
+    "USER_NUMBER": "NUMBER",
+    "USER_PREDIR": "PREDIR",
+    "USER_STNAME": "STNAME",
+    "USER_STSUFFIX": "STSUFFIX",
+    "USER_POSTDIR": "POSTDIR",
+    "USER_UNITTYPE": "UNITTYPE",
+    "USER_UNITNUM": "UNITNUM",
+    "USER_MAILCITY": "MAILCITY",
+    "USER_ZIP": "ZIP",
+    "USER_ZIP_4": "ZIP+4",
+    "USER_LAT": "LAT",
+    "USER_LONG": "LONG",
+    "USER_FEATID": "FEATID",
+    "USER_COUNTYID": "COUNTYID",
+    "USER_COUNTY": "COUNTY",
+    "USER_JURISDICTION": "JURISDICTION",
+    "USER_FIRECODE": "FIRECODE",
+    "USER_POLCODE": "POLCODE",
+    "USER_EFFDATE": "EFFDATE",
+    "USER_TDTCODE": "TDTCODE",
 }
 
-# Open the zip file
-with zipfile.ZipFile(zip_filename, 'r') as zf:
+
+with zipfile.ZipFile(ZIP_FILENAME, "r") as zf:
     csv_in_zip = zf.namelist()[0]
     with zf.open(csv_in_zip) as f:
-        reader = pd.read_csv(f, chunksize=10000, usecols=columns_to_keep.keys())
+        reader = pd.read_csv(
+            f, chunksize=10000, usecols=COLUMNS_TO_KEEP.keys(), dtype=str
+        )
 
         first_chunk = True
         for chunk in reader:
-            chunk.rename(columns=columns_to_keep, inplace=True)
+            chunk.rename(columns=COLUMNS_TO_KEEP, inplace=True)
+            chunk = chunk.applymap(to_upper)
+            chunk["EFFDATE"] = chunk["EFFDATE"].apply(date_only)
+            for col, val in FIXED_CODES.items():
+                chunk[col] = val
             if first_chunk:
-                chunk.to_csv(csv_filename, index=False, mode='w', header=True)
+                chunk.to_csv(CSV_FILENAME, index=False, mode="w", header=True)
                 first_chunk = False
             else:
-                chunk.to_csv(csv_filename, index=False, mode='a', header=False)
+                chunk.to_csv(CSV_FILENAME, index=False, mode="a", header=False)
 
-# Zip the cleaned CSV file
-with zipfile.ZipFile(final_zip_name, 'w', zipfile.ZIP_DEFLATED) as zf:
-    zf.write(csv_filename)
+with zipfile.ZipFile(FINAL_ZIP_NAME, "w", zipfile.ZIP_DEFLATED) as zf:
+    zf.write(CSV_FILENAME)
 
-print(f"Successfully created {final_zip_name} with {csv_filename} inside.")
+print(f"Successfully created {FINAL_ZIP_NAME} with {CSV_FILENAME} inside.")

--- a/clean_siteaddress.py
+++ b/clean_siteaddress.py
@@ -1,49 +1,90 @@
+"""Clean and standardize the SiteAddress data for PointMatch."""
+
+from typing import Dict, List
+
 import pandas as pd
 
-# Load the raw site address data
-raw_file = 'SiteAddress08152025.csv'
-output_file = 'SiteAddressPtMatch.csv'
+from process_data import FIXED_CODES, date_only, to_upper
+
+
+RAW_FILE = "SiteAddress08152025.csv"
+OUTPUT_FILE = "SiteAddressPtMatch.csv"
 
 # Columns to extract and their mapping to PointMatch schema
-columns_to_keep = {
-    'addrnum': 'NUMBER',
-    'roadpredir': 'PREDIR',
-    'roadname': 'STNAME',
-    'roadtype': 'STSUFFIX',
-    'roadpostdir': 'POSTDIR',
-    'unittype': 'UNITTYPE',
-    'unitid': 'UNITNUM',
-    'postcomm': 'MAILCITY',
-    'postal': 'ZIP',
-    'siteaddid': 'FEATID',
-    'County': 'COUNTY',
-    'municipality': 'JURISDICTION',
-    'created_date': 'EFFDATE'
+COLUMNS_TO_KEEP: Dict[str, str] = {
+    "addrnum": "NUMBER",
+    "roadpredir": "PREDIR",
+    "roadname": "STNAME",
+    "roadtype": "STSUFFIX",
+    "roadpostdir": "POSTDIR",
+    "unittype": "UNITTYPE",
+    "unitid": "UNITNUM",
+    "postcomm": "MAILCITY",
+    "postal": "ZIP",
+    "County": "COUNTY",
+    "municipality": "JURISDICTION",
+    "created_date": "EFFDATE",
 }
 
-# Read the CSV and select necessary columns
-site_df = pd.read_csv(raw_file, dtype=str)[list(columns_to_keep.keys())]
-site_df.rename(columns=columns_to_keep, inplace=True)
+ALL_COLUMNS: List[str] = [
+    "NUMBER",
+    "PREDIR",
+    "STNAME",
+    "STSUFFIX",
+    "POSTDIR",
+    "UNITTYPE",
+    "UNITNUM",
+    "MAILCITY",
+    "ZIP",
+    "ZIP+4",
+    "LAT",
+    "LONG",
+    "FEATID",
+    "COUNTYID",
+    "COUNTY",
+    "JURISDICTION",
+    "FIRECODE",
+    "POLCODE",
+    "EFFDATE",
+    "TDTCODE",
+]
 
-# Ensure all expected columns exist
-all_columns = ['NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR',
-               'UNITTYPE', 'UNITNUM', 'MAILCITY', 'ZIP', 'ZIP+4',
-               'LAT', 'LONG', 'FEATID', 'COUNTYID', 'COUNTY',
-               'JURISDICTION', 'FIRECODE', 'POLCODE', 'EFFDATE', 'TDTCODE']
-for col in all_columns:
-    if col not in site_df:
-        site_df[col] = ''
-    else:
-        site_df[col] = site_df[col].fillna('')
 
-# Drop unit information and keep unique base addresses
-base_cols = ['NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR', 'MAILCITY', 'ZIP']
-site_df['UNITTYPE'] = ''
-site_df['UNITNUM'] = ''
-site_df = site_df.drop_duplicates(subset=base_cols)
+def clean_siteaddress(raw_file: str = RAW_FILE, output_file: str = OUTPUT_FILE) -> None:
+    """Read raw site address CSV and produce a normalized PointMatch file."""
 
-# Reorder columns to match PointMatch schema
-site_df = site_df[all_columns]
+    site_df = pd.read_csv(raw_file, dtype=str)[list(COLUMNS_TO_KEEP.keys())]
+    site_df.rename(columns=COLUMNS_TO_KEEP, inplace=True)
 
-# Save the cleaned data
-site_df.to_csv(output_file, index=False)
+    site_df = site_df.applymap(to_upper)
+    site_df["EFFDATE"] = site_df["EFFDATE"].apply(date_only)
+
+    for col, val in FIXED_CODES.items():
+        site_df[col] = val
+
+    for col in ALL_COLUMNS:
+        if col not in site_df:
+            site_df[col] = ""
+        else:
+            site_df[col] = site_df[col].fillna("")
+
+    base_cols = [
+        "NUMBER",
+        "PREDIR",
+        "STNAME",
+        "STSUFFIX",
+        "POSTDIR",
+        "MAILCITY",
+        "ZIP",
+    ]
+    site_df["UNITTYPE"] = ""
+    site_df["UNITNUM"] = ""
+    site_df = site_df.drop_duplicates(subset=base_cols)
+
+    site_df = site_df[ALL_COLUMNS]
+    site_df.to_csv(output_file, index=False)
+
+
+if __name__ == "__main__":
+    clean_siteaddress()
+

--- a/merge_addresses.py
+++ b/merge_addresses.py
@@ -1,29 +1,65 @@
 import argparse
+from typing import List
+
 import pandas as pd
 
-STLUCIE_COLUMNS = [
-    'NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR', 'UNITTYPE',
-    'UNITNUM', 'MAILCITY', 'ZIP', 'ZIP+4', 'LAT', 'LONG', 'FEATID',
-    'COUNTYID', 'COUNTY', 'JURISDICTION', 'FIRECODE', 'POLCODE', 'EFFDATE', 'TDTCODE'
+from process_data import FIXED_CODES, date_only, to_upper
+
+
+STLUCIE_COLUMNS: List[str] = [
+    "NUMBER",
+    "PREDIR",
+    "STNAME",
+    "STSUFFIX",
+    "POSTDIR",
+    "UNITTYPE",
+    "UNITNUM",
+    "MAILCITY",
+    "ZIP",
+    "ZIP+4",
+    "LAT",
+    "LONG",
+    "FEATID",
+    "COUNTYID",
+    "COUNTY",
+    "JURISDICTION",
+    "FIRECODE",
+    "POLCODE",
+    "EFFDATE",
+    "TDTCODE",
 ]
 
 RENAME_MAP = {
-    'addrnum': 'NUMBER',
-    'roadpredir': 'PREDIR',
-    'roadname': 'STNAME',
-    'roadtype': 'STSUFFIX',
-    'roadpostdir': 'POSTDIR',
-    'unittype': 'UNITTYPE',
-    'unitid': 'UNITNUM',
-    'postcomm': 'MAILCITY',
-    'postal': 'ZIP',
-    'municipality': 'JURISDICTION',
+    "addrnum": "NUMBER",
+    "roadpredir": "PREDIR",
+    "roadname": "STNAME",
+    "roadtype": "STSUFFIX",
+    "roadpostdir": "POSTDIR",
+    "unittype": "UNITTYPE",
+    "unitid": "UNITNUM",
+    "postcomm": "MAILCITY",
+    "postal": "ZIP",
+    "municipality": "JURISDICTION",
 }
 
 
 def load_gis_csv(path: str) -> pd.DataFrame:
     """Load the gzipped GIS export."""
-    return pd.read_csv(path, compression='gzip')
+    return pd.read_csv(path, compression="gzip", dtype=str)
+
+
+def normalize_df(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.applymap(to_upper)
+    if "EFFDATE" in df.columns:
+        df["EFFDATE"] = df["EFFDATE"].apply(date_only)
+    if "JURISDICTION" in df.columns:
+        df["JURISDICTION"] = (
+            df["JURISDICTION"].fillna("UNINCORPORATED").replace("", "UNINCORPORATED")
+        )
+    for col, val in FIXED_CODES.items():
+        if col in df.columns:
+            df[col] = val
+    return df
 
 
 def standardize_gis(df: pd.DataFrame) -> pd.DataFrame:
@@ -32,13 +68,12 @@ def standardize_gis(df: pd.DataFrame) -> pd.DataFrame:
     for col in STLUCIE_COLUMNS:
         if col not in df.columns:
             df[col] = pd.NA
-    df['COUNTY'] = df.get('County', pd.NA).fillna('St. Lucie')
-    df['COUNTYID'] = df['COUNTYID'].fillna(111)
+    df = normalize_df(df)
     return df[STLUCIE_COLUMNS]
 
 
 def merge_datasets(original_csv: str, new_csv: str, output_csv: str) -> None:
-    df_old = pd.read_csv(original_csv)
+    df_old = normalize_df(pd.read_csv(original_csv, dtype=str))
     df_new = load_gis_csv(new_csv)
     df_new = standardize_gis(df_new)
     merged = pd.concat([df_old, df_new], ignore_index=True)
@@ -46,10 +81,12 @@ def merge_datasets(original_csv: str, new_csv: str, output_csv: str) -> None:
     merged.to_csv(output_csv, index=False)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Merge new GIS records into St. Lucie dataset')
-    parser.add_argument('stlucie_csv', help='Existing St. Lucie CSV file')
-    parser.add_argument('gis_csv', help='Gzipped GIS export')
-    parser.add_argument('output_csv', help='Output CSV path')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Merge new GIS records into St. Lucie dataset"
+    )
+    parser.add_argument("stlucie_csv", help="Existing St. Lucie CSV file")
+    parser.add_argument("gis_csv", help="Gzipped GIS export")
+    parser.add_argument("output_csv", help="Output CSV path")
     args = parser.parse_args()
     merge_datasets(args.stlucie_csv, args.gis_csv, args.output_csv)

--- a/process_data.py
+++ b/process_data.py
@@ -1,47 +1,118 @@
 import csv
 import gzip
 
+
+FIXED_CODES = {
+    'FEATID': '2403646',
+    'COUNTYID': '111',
+    'COUNTY': 'ST. LUCIE',
+    'FIRECODE': '73',
+    'POLCODE': '377',
+}
+
+
+def to_upper(value: str) -> str:
+    return value.upper() if isinstance(value, str) else value
+
+
+def date_only(value: str) -> str:
+    if not value:
+        return ''
+    return value.split('T')[0].split(' ')[0]
+
+
+def build_row(row: dict) -> tuple:
+    return (
+        to_upper(row.get('addrnum', '')),
+        to_upper(row.get('roadpredir', '')),
+        to_upper(row.get('roadname', '')),
+        to_upper(row.get('roadtype', '')),
+        to_upper(row.get('roadpostdir', '')),
+        '',  # UNITTYPE
+        '',  # UNITNUM
+        to_upper(row.get('postcomm', '')),
+        to_upper(row.get('postal', '')),
+        '',  # ZIP+4
+        '',  # LAT
+        '',  # LONG
+        FIXED_CODES['FEATID'],
+        FIXED_CODES['COUNTYID'],
+        FIXED_CODES['COUNTY'],
+        to_upper(row.get('municipality', '')),
+        FIXED_CODES['FIRECODE'],
+        FIXED_CODES['POLCODE'],
+        date_only(row.get('created_date', '')),
+        '',  # TDTCODE
+    )
+
+
+def build_existing_row(row: dict) -> tuple:
+    return (
+        to_upper(row.get('NUMBER', '')),
+        to_upper(row.get('PREDIR', '')),
+        to_upper(row.get('STNAME', '')),
+        to_upper(row.get('STSUFFIX', '')),
+        to_upper(row.get('POSTDIR', '')),
+        '',  # UNITTYPE
+        '',  # UNITNUM
+        to_upper(row.get('MAILCITY', '')),
+        to_upper(row.get('ZIP', '')),
+        '',  # ZIP+4
+        '',  # LAT
+        '',  # LONG
+        FIXED_CODES['FEATID'],
+        FIXED_CODES['COUNTYID'],
+        FIXED_CODES['COUNTY'],
+        to_upper(row.get('JURISDICTION', '')),
+        FIXED_CODES['FIRECODE'],
+        FIXED_CODES['POLCODE'],
+        date_only(row.get('EFFDATE', '')),
+        '',  # TDTCODE
+    )
+
+
 def process_files():
     stlucie_addresses = set()
     with open('StLucie.csv', 'r') as stlucie_file:
-        reader = csv.reader(stlucie_file)
-        header = next(reader)
+        reader = csv.DictReader(stlucie_file)
         for row in reader:
-            stlucie_addresses.add(tuple(row))
+            stlucie_addresses.add(build_existing_row(row))
 
-    with gzip.open('StAddy.csv.gz', 'rt') as staddy_file, gzip.open('PointMatch.csv.gz', 'wt', newline='') as pointmatch_file:
+    with gzip.open('StAddy.csv.gz', 'rt') as staddy_file, gzip.open(
+        'PointMatch.csv.gz', 'wt', newline=''
+    ) as pointmatch_file:
         reader = csv.DictReader(staddy_file)
         writer = csv.writer(pointmatch_file)
 
         # Write header to PointMatch.csv.gz
-        writer.writerow(['NUMBER', 'PREDIR', 'STNAME', 'STSUFFIX', 'POSTDIR', 'UNITTYPE', 'UNITNUM', 'MAILCITY', 'ZIP', 'ZIP+4', 'LAT', 'LONG', 'FEATID', 'COUNTYID', 'COUNTY', 'JURISDICTION', 'FIRECODE', 'POLCODE', 'EFFDATE', 'TDTCODE'])
+        writer.writerow([
+            'NUMBER',
+            'PREDIR',
+            'STNAME',
+            'STSUFFIX',
+            'POSTDIR',
+            'UNITTYPE',
+            'UNITNUM',
+            'MAILCITY',
+            'ZIP',
+            'ZIP+4',
+            'LAT',
+            'LONG',
+            'FEATID',
+            'COUNTYID',
+            'COUNTY',
+            'JURISDICTION',
+            'FIRECODE',
+            'POLCODE',
+            'EFFDATE',
+            'TDTCODE',
+        ])
 
         for row in reader:
-            staddy_address = (
-                row.get('addrnum', ''),
-                row.get('roadpredir', ''),
-                row.get('roadname', ''),
-                row.get('roadtype', ''),
-                row.get('roadpostdir', ''),
-                row.get('unittype', ''),
-                row.get('unitid', ''),
-                row.get('postcomm', ''),
-                row.get('postal', ''),
-                '',  # ZIP+4
-                '',  # LAT
-                '',  # LONG
-                '',  # FEATID
-                '',  # COUNTYID
-                row.get('County', ''),
-                row.get('municipality', ''),
-                '',  # FIRECODE
-                '',  # POLCODE
-                row.get('created_date', ''),
-                ''  # TDTCODE
-            )
-
+            staddy_address = build_row(row)
             if staddy_address not in stlucie_addresses:
                 writer.writerow(staddy_address)
+
 
 if __name__ == '__main__':
     process_files()


### PR DESCRIPTION
## Summary
- Refactor SiteAddress cleaner to reuse shared utilities for uppercasing, date-only EFFDATE, and constant identifiers.
- Apply common FIXED_CODES/to_upper/date_only helpers in zipped CSV cleaning and dataset merging.
- Normalize merged datasets with consistent county and jurisdiction values.

## Testing
- `python -m py_compile clean_siteaddress.py process_data.py clean_data.py merge_addresses.py`


------
https://chatgpt.com/codex/tasks/task_e_689f67b044488332853af2889d24ada7